### PR TITLE
Resolve the thumbnail_server and page thumbnail creation issue by fixing Nearspark and Photomnemonic.

### DIFF
--- a/charts/nearspark/templates/ingress.yaml
+++ b/charts/nearspark/templates/ingress.yaml
@@ -25,7 +25,7 @@ spec:
       http:
         paths:
         - path: /nearspark
-          pathType: ImplementationSpecific
+          pathType: Prefix
           backend:
             service:
               name: nearspark

--- a/charts/nearspark/values.yaml
+++ b/charts/nearspark/values.yaml
@@ -54,6 +54,7 @@ ingress:
   enabled: true
   annotations: 
     kubernetes.io/ingress.class: haproxy
+    haproxy.org/path-rewrite: /nearspark/(.*) /\1
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   # hosts:

--- a/charts/reticulum/templates/deployment.yaml
+++ b/charts/reticulum/templates/deployment.yaml
@@ -189,7 +189,7 @@ spec:
             - name: turkeyCfg_YTDL_HOST
               value: "https://hubs-ytdl-fsu7tyt32a-uc.a.run.app"
             - name: turkeyCfg_PHOTOMNEMONIC
-              value: "https://photomnemonic-fsu7tyt32a-uc.a.run.app"
+              value: "http://photomnemonic:5000"
             - name: turkeyCfg_SPEELYCAPTOR
               value: "http://speelycaptor:5000"
             - name: turkeyCfg_STORAGE_QUOTA_GB

--- a/charts/spoke/templates/deployment.yaml
+++ b/charts/spoke/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
             - name: turkeyCfg_thumbnail_server
-              value: nearspark.reticulum.io
+              value: cors.{{ .Values.global.domain }}/nearspark
             - name: turkeyCfg_base_assets_path
               value: https://assets.{{ .Values.global.domain }}/spoke/
             - name: turkeyCfg_non_cors_proxy_domains

--- a/values.aws.yaml
+++ b/values.aws.yaml
@@ -41,7 +41,7 @@ certs:
 
 env:
   - name: turkeyCfg_thumbnail_server
-    value: nearspark.reticulum.io
+    value: cors.{{ .Values.global.domain }}/nearspark
   - name: turkeyCfg_tier
     value: p1
 

--- a/values.gcp.yaml
+++ b/values.gcp.yaml
@@ -42,7 +42,7 @@ certs:
 
 env:
   - name: turkeyCfg_thumbnail_server
-    value: nearspark.reticulum.io
+    value: cors.{{ .Values.global.domain }}/nearspark
   - name: turkeyCfg_tier
     value: p1
 

--- a/values.scale.yaml
+++ b/values.scale.yaml
@@ -42,7 +42,7 @@ certs:
 
 env:
   - name: turkeyCfg_thumbnail_server
-    value: nearspark.reticulum.io
+    value: cors.{{ .Values.global.domain }}/nearspark
   - name: turkeyCfg_tier
     value: p1
 

--- a/values.yaml
+++ b/values.yaml
@@ -42,7 +42,7 @@ certs:
 
 env:
   - name: turkeyCfg_thumbnail_server
-    value: nearspark.reticulum.io
+    value: cors.{{ .Values.global.domain }}/nearspark
   - name: turkeyCfg_tier
     value: p1
 


### PR DESCRIPTION
## This pull request addresses two critical issues:

### Page Preview Thumbnail Creation Issue:

 - Previously, when pasting any link on the hub, a page-preview thumbnail was not generated correctly. The Photomnemonic changes in this pull request resolve this broken link issue.🛠️

### Broken Thumbnail Issue:
- The Spoke Asset thumbnail had a broken link issue, affecting other hubs as well. The Nearspark changes in this pull request fix the broken thumbnail issue for assets on hubs. 🛠️